### PR TITLE
Add manifests

### DIFF
--- a/manifests/octopub-audits-mysql.yaml
+++ b/manifests/octopub-audits-mysql.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: 10000
       targetPort: 10000
-      name: http-port
+      name: http-audit
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -28,6 +28,9 @@ spec:
       containers:
         - name: auditservice
           image: octopussamples/octopub-audit-microservice-mysql
+          ports:
+            - name: http-audit
+              containerPort: 10000
           env:
             - name: DATABASE_PASSWORD
               valueFrom:
@@ -41,8 +44,11 @@ spec:
             - name: DATABASE_NAME
               value: "octopub_Development"
             - name: DATABASE_USERNAME
-              value: "root"
+              valueFrom:
+                secretKeyRef:
+                  name: database-credentials
+                  key: database-user
             - name: MIGRATE_AT_START
               value: "false"
             - name: COGNITO_DISABLE_AUTH
-              value: "false"
+              value: "true"

--- a/manifests/octopub-audits-mysql.yaml
+++ b/manifests/octopub-audits-mysql.yaml
@@ -1,16 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: octopub-audit-cluster-ip
-spec:
-  type: ClusterIP
-  selector:
-    component: auditservice
-  ports:
-    - port: 10000
-      targetPort: 10000
-      name: http-audit
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/octopub-audits-mysql.yaml
+++ b/manifests/octopub-audits-mysql.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octopub-audit-cluster-ip
+spec:
+  type: ClusterIP
+  selector:
+    component: auditservice
+  ports:
+    - port: 10000
+      targetPort: 10000
+      name: http-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octopub-audit-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: auditservice
+  template:
+    metadata:
+      labels:
+        component: auditservice
+    spec:
+      containers:
+        - name: auditservice
+          image: octopussamples/octopub-audit-microservice-mysql
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database-credentials
+                  key: database-password
+            - name: DATABASE_HOSTNAME
+              value: "192.168.1.64"
+            - name: DATABASE_PORT
+              value: "30000"
+            - name: DATABASE_NAME
+              value: "octopub_Development"
+            - name: DATABASE_USERNAME
+              value: "root"
+            - name: MIGRATE_AT_START
+              value: "false"
+            - name: COGNITO_DISABLE_AUTH
+              value: "false"

--- a/manifests/octopub-audits-service.yaml
+++ b/manifests/octopub-audits-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octopub-audit-cluster-ip
+spec:
+  type: ClusterIP
+  selector:
+    component: auditservice
+  ports:
+    - port: 10000
+      targetPort: 10000
+      name: http-audit

--- a/manifests/octopub-database-secret.yaml
+++ b/manifests/octopub-database-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: database-credentials
+type: Opaque
+stringData:
+  database-password: "YourPasswordHere!!"

--- a/manifests/octopub-database-secret.yaml
+++ b/manifests/octopub-database-secret.yaml
@@ -5,3 +5,4 @@ metadata:
 type: Opaque
 stringData:
   database-password: "YourPasswordHere!!"
+  database-user: "root"

--- a/manifests/octopub-frontend-service.yaml
+++ b/manifests/octopub-frontend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octopub-frontend-cluster-ip
+spec:
+  type: ClusterIP
+  selector:
+    component: web
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http-port

--- a/manifests/octopub-frontend.yaml
+++ b/manifests/octopub-frontend.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octopub-frontend-cluster-ip
+spec:
+  type: ClusterIP
+  selector:
+    component: web
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octopub-frontend-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: web
+  template:
+    metadata:
+      labels:
+        component: web
+    spec:
+      containers:
+        - name: web
+          image: octopussamples/octopub-frontend
+          ports:
+            - containerPort: 8080
+              name: http-port
+          env:
+            - name: UDL_SKIPEMPTY_SETVALUE_1
+              value: "[/usr/share/nginx/html/config.json][productEndpoint]http://octopub-productservice-cluster-ip:8083/api/products"
+            - name: UDL_SKIPEMPTY_SETVALUE_2
+              value: "[/usr/share/nginx/html/config.json][productHealthEndpoint]http://octopub-productservice-cluster-ip:8083/health/products"
+            - name: UDL_SKIPEMPTY_SETVALUE_3
+              value: "[/usr/share/nginx/html/config.json][auditEndpoint]http://octopub-audit-cluster-ip:10000/api/audits"
+            - name: UDL_SKIPEMPTY_SETVALUE_4
+              value: "[/usr/share/nginx/html/config.json][auditHealthEndpoint]http://octopub-audit-cluster-ip:10000/health/audits"
+            - name: UDL_SKIPEMPTY_SETVALUE_5
+              value: "[/usr/share/nginx/html/config.json][customPrimaryColor]"
+            - name: UDL_SKIPEMPTY_SETVALUE_6
+              value: "[/usr/share/nginx/html/config.json][customSecondaryColor]"
+            - name: UDL_SKIPEMPTY_SETVALUE_7
+              value: "[/usr/share/nginx/html/config.json][customBackgroundColor]"
+            - name: UDL_SKIPEMPTY_SETVALUE_8
+              value: "[/usr/share/nginx/html/config.json][customPaperColor]"
+            - name: UDL_SKIPEMPTY_SETVALUE_9
+              value: "[/usr/share/nginx/html/config.json][overrideTheme]"

--- a/manifests/octopub-frontend.yaml
+++ b/manifests/octopub-frontend.yaml
@@ -1,16 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: octopub-frontend-cluster-ip
-spec:
-  type: ClusterIP
-  selector:
-    component: web
-  ports:
-    - port: 8080
-      targetPort: 8080
-      name: http-port
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/octopub-frontend.yaml
+++ b/manifests/octopub-frontend.yaml
@@ -18,22 +18,3 @@ spec:
           ports:
             - containerPort: 8080
               name: http-port
-          env:
-            - name: UDL_SKIPEMPTY_SETVALUE_1
-              value: "[/usr/share/nginx/html/config.json][productEndpoint]http://octopub-productservice-cluster-ip:8083/api/products"
-            - name: UDL_SKIPEMPTY_SETVALUE_2
-              value: "[/usr/share/nginx/html/config.json][productHealthEndpoint]http://octopub-productservice-cluster-ip:8083/health/products"
-            - name: UDL_SKIPEMPTY_SETVALUE_3
-              value: "[/usr/share/nginx/html/config.json][auditEndpoint]http://octopub-audit-cluster-ip:10000/api/audits"
-            - name: UDL_SKIPEMPTY_SETVALUE_4
-              value: "[/usr/share/nginx/html/config.json][auditHealthEndpoint]http://octopub-audit-cluster-ip:10000/health/audits"
-            - name: UDL_SKIPEMPTY_SETVALUE_5
-              value: "[/usr/share/nginx/html/config.json][customPrimaryColor]"
-            - name: UDL_SKIPEMPTY_SETVALUE_6
-              value: "[/usr/share/nginx/html/config.json][customSecondaryColor]"
-            - name: UDL_SKIPEMPTY_SETVALUE_7
-              value: "[/usr/share/nginx/html/config.json][customBackgroundColor]"
-            - name: UDL_SKIPEMPTY_SETVALUE_8
-              value: "[/usr/share/nginx/html/config.json][customPaperColor]"
-            - name: UDL_SKIPEMPTY_SETVALUE_9
-              value: "[/usr/share/nginx/html/config.json][overrideTheme]"

--- a/manifests/octopub-ingress.yaml
+++ b/manifests/octopub-ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /api/audits
+        pathType: Prefix
+        backend:
+          service:
+            name: octopub-audit-cluster-ip
+            port:
+              number: 10000
+      - path: /api/products
+        pathType: Prefix
+        backend:
+          service:
+            name: octopub-productservice-cluster-ip
+            port:
+              number: 8083
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name:  octopub-frontend-cluster-ip
+            port:
+              number: 8080

--- a/manifests/octopub-ingress.yaml
+++ b/manifests/octopub-ingress.yaml
@@ -1,9 +1,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: minimal-ingress
+  name: octopub-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   ingressClassName: nginx
   rules:
@@ -15,18 +14,32 @@ spec:
           service:
             name: octopub-audit-cluster-ip
             port:
-              number: 10000
+              name: http-audit
+      - path: /health/audits
+        pathType: Prefix
+        backend:
+          service:
+            name: octopub-audit-cluster-ip
+            port:
+              name: http-audit
       - path: /api/products
         pathType: Prefix
         backend:
           service:
             name: octopub-productservice-cluster-ip
             port:
-              number: 8083
+              name: http-product
+      - path: /health/products
+        pathType: Prefix
+        backend:
+          service:
+            name: octopub-productservice-cluster-ip
+            port:
+              name: http-product
       - path: /
         pathType: Prefix
         backend:
           service:
             name:  octopub-frontend-cluster-ip
             port:
-              number: 8080
+              name: http-web

--- a/manifests/octopub-ingress.yaml
+++ b/manifests/octopub-ingress.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http:
+  - host: 
+    http:
       paths:
       - path: /api/audits
         pathType: Prefix

--- a/manifests/octopub-ingress.yaml
+++ b/manifests/octopub-ingress.yaml
@@ -42,4 +42,4 @@ spec:
           service:
             name:  octopub-frontend-cluster-ip
             port:
-              name: http-web
+              name: http-port

--- a/manifests/octopub-ingress.yaml
+++ b/manifests/octopub-ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: octopub-ingress
-  annotations:
 spec:
   ingressClassName: nginx
   rules:

--- a/manifests/octopub-ingress.yaml
+++ b/manifests/octopub-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: 
+  - host: ""
     http:
       paths:
       - path: /api/audits

--- a/manifests/octopub-products-mysql.yaml
+++ b/manifests/octopub-products-mysql.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octopub-productservice-cluster-ip
+spec:
+  type: ClusterIP
+  selector:
+    component: productservice
+  ports:
+    - port: 8083
+      targetPort: 8083
+      name: http-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octopub-productservice-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: productservice
+  template:
+    metadata:
+      labels:
+        component: productservice
+    spec:
+      containers:
+        - name: productservice
+          image: octopussamples/octopub-products-microservice-mysql
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database-credentials
+                  key: database-password
+            - name: DATABASE_HOSTNAME
+              value: "192.168.1.64"
+            - name: DATABASE_PORT
+              value: "30000"
+            - name: DATABASE_NAME
+              value: "octopub_Development"
+            - name: DATABASE_USERNAME
+              value: "root"
+            - name: MIGRATE_AT_START
+              value: "false"
+            - name: COGNITO_DISABLE_AUTH
+              value: "false"

--- a/manifests/octopub-products-mysql.yaml
+++ b/manifests/octopub-products-mysql.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: 8083
       targetPort: 8083
-      name: http-port
+      name: http-product
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -28,6 +28,9 @@ spec:
       containers:
         - name: productservice
           image: octopussamples/octopub-products-microservice-mysql
+          ports:
+            - name: http-product
+              containerPort: 8083
           env:
             - name: DATABASE_PASSWORD
               valueFrom:
@@ -41,8 +44,11 @@ spec:
             - name: DATABASE_NAME
               value: "octopub_Development"
             - name: DATABASE_USERNAME
-              value: "root"
+              valueFrom:
+                secretKeyRef:
+                  name: database-credentials
+                  key: database-user
             - name: MIGRATE_AT_START
               value: "false"
             - name: COGNITO_DISABLE_AUTH
-              value: "false"
+              value: "true"

--- a/manifests/octopub-products-mysql.yaml
+++ b/manifests/octopub-products-mysql.yaml
@@ -1,16 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: octopub-productservice-cluster-ip
-spec:
-  type: ClusterIP
-  selector:
-    component: productservice
-  ports:
-    - port: 8083
-      targetPort: 8083
-      name: http-product
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/octopub-products-service.yaml
+++ b/manifests/octopub-products-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octopub-productservice-cluster-ip
+spec:
+  type: ClusterIP
+  selector:
+    component: productservice
+  ports:
+    - port: 8083
+      targetPort: 8083
+      name: http-product


### PR DESCRIPTION
Adding manifests folder with files to support the Raw YAML deployment type.  This is added to support moving away from OctoPetShop and over to Octopub.  This will allow us to create both a sample and demo projects that reference files from git.