### PR TITLE
Updating kustomize to pull from ghcr

### DIFF
--- a/kustomize/octopub-audits-mysql/envs/Development/kustomization.yaml
+++ b/kustomize/octopub-audits-mysql/envs/Development/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-audit-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-audits-mysql/envs/Production/kustomization.yaml
+++ b/kustomize/octopub-audits-mysql/envs/Production/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-audit-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-audits-mysql/envs/Staging/kustomization.yaml
+++ b/kustomize/octopub-audits-mysql/envs/Staging/kustomization.yaml
@@ -25,6 +25,6 @@ configMapGenerator:
     env: variables.properties
 
 images:
-  - name: octopussamples/octopub-audit-microservice-mysql
+  - name: ghcr.io/octopussamples/octopub-audit-microservice-mysql
     newName: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-audits-mysql/envs/Test/kustomization.yaml
+++ b/kustomize/octopub-audits-mysql/envs/Test/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-audit-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-audit-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-frontend/envs/Development/kustomization.yaml
+++ b/kustomize/octopub-frontend/envs/Development/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 
 images:
   - name: octopussamples/octopub-frontend
-    newName: #{Octopus.Action.Package[octopub-frontend].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-frontend].PackageId}
     newTag: #{Octopus.Action.Package[octopub-frontend].PackageVersion}

--- a/kustomize/octopub-frontend/envs/Production/kustomization.yaml
+++ b/kustomize/octopub-frontend/envs/Production/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 
 images:
   - name: octopussamples/octopub-frontend
-    newName: #{Octopus.Action.Package[octopub-frontend].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-frontend].PackageId}
     newTag: #{Octopus.Action.Package[octopub-frontend].PackageVersion}

--- a/kustomize/octopub-frontend/envs/Staging/kustomization.yaml
+++ b/kustomize/octopub-frontend/envs/Staging/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 
 images:
   - name: octopussamples/octopub-frontend
-    newName: #{Octopus.Action.Package[octopub-frontend].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-frontend].PackageId}
     newTag: #{Octopus.Action.Package[octopub-frontend].PackageVersion}

--- a/kustomize/octopub-frontend/envs/Test/kustomization.yaml
+++ b/kustomize/octopub-frontend/envs/Test/kustomization.yaml
@@ -20,5 +20,5 @@ patches:
 
 images:
   - name: octopussamples/octopub-frontend
-    newName: #{Octopus.Action.Package[octopub-frontend].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-frontend].PackageId}
     newTag: #{Octopus.Action.Package[octopub-frontend].PackageVersion}

--- a/kustomize/octopub-products-mysql/envs/Development/kustomization.yaml
+++ b/kustomize/octopub-products-mysql/envs/Development/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-products-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-products-mysql/envs/Production/kustomization.yaml
+++ b/kustomize/octopub-products-mysql/envs/Production/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-products-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-products-mysql/envs/Staging/kustomization.yaml
+++ b/kustomize/octopub-products-mysql/envs/Staging/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-products-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageVersion}

--- a/kustomize/octopub-products-mysql/envs/Test/kustomization.yaml
+++ b/kustomize/octopub-products-mysql/envs/Test/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
   - name: octopussamples/octopub-products-microservice-mysql
-    newName: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
+    newName: ghcr.io/#{Octopus.Action.Package[octopub-products-microservice-mysql].PackageId}
     newTag: #{Octopus.Action.Package[octopub-products-microservice-mysql].PackageVersion}


### PR DESCRIPTION
The Octopus variable for PackageId in the Kustomization.yaml files does not include the repository it comes from, despite selecting ghcr.  You need to preface the PackageId variable with `ghcr.io/` so it pull from the correct registry.