### PR TITLE
Adding feature toggle environment variables for manifests

### DIFF
--- a/manifests/octopub-frontend.yaml
+++ b/manifests/octopub-frontend.yaml
@@ -18,3 +18,8 @@ spec:
           ports:
             - containerPort: 8080
               name: http-port
+          env:
+            - name: clientIdentifier
+              value: ""
+            - name: featureToggleSlug
+              value: ""


### PR DESCRIPTION
Adds the placeholders for the environment variables to support using Octopus Feature Toggles.  The code for front-end has already been updated to work with missing or blank environment variables.  If the variables are passed in, the startup script will update the config.json file so when the application starts it will read the `clientIdentifer` and `featureToggleSlug` and respond accordingly.