### PR TITLE
Adding feature toggle environment variables for kustomize

### DIFF
--- a/kustomize/octopub-frontend/envs/Development/octopub-frontend-deployment.yaml
+++ b/kustomize/octopub-frontend/envs/Development/octopub-frontend-deployment.yaml
@@ -1,3 +1,11 @@
 - op: replace
   path: /spec/template/spec/containers/0/ports/0/containerPort
   value: #{Project.Frontend.ContainerPort}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/0/name
+  value: #{Project.Frontend.ClientIdentifier}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/1/name
+  value: #{Project.Frontend.FeatureToggleSlug}

--- a/kustomize/octopub-frontend/envs/Production/octopub-frontend-deployment.yaml
+++ b/kustomize/octopub-frontend/envs/Production/octopub-frontend-deployment.yaml
@@ -1,3 +1,11 @@
 - op: replace
   path: /spec/template/spec/containers/0/ports/0/containerPort
   value: #{Project.Frontend.ContainerPort}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/0/name
+  value: #{Project.Frontend.ClientIdentifier}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/1/name
+  value: #{Project.Frontend.FeatureToggleSlug}

--- a/kustomize/octopub-frontend/envs/Staging/octopub-frontend-deployment.yaml
+++ b/kustomize/octopub-frontend/envs/Staging/octopub-frontend-deployment.yaml
@@ -1,3 +1,11 @@
 - op: replace
   path: /spec/template/spec/containers/0/ports/0/containerPort
   value: #{Project.Frontend.ContainerPort}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/0/name
+  value: #{Project.Frontend.ClientIdentifier}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/1/name
+  value: #{Project.Frontend.FeatureToggleSlug}

--- a/kustomize/octopub-frontend/envs/Test/octopub-frontend-deployment.yaml
+++ b/kustomize/octopub-frontend/envs/Test/octopub-frontend-deployment.yaml
@@ -1,3 +1,11 @@
 - op: replace
   path: /spec/template/spec/containers/0/ports/0/containerPort
   value: #{Project.Frontend.ContainerPort}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/0/name
+  value: #{Project.Frontend.ClientIdentifier}
+
+- op: replace
+  path: /spec/template/spec/containers/0/env/1/name
+  value: #{Project.Frontend.FeatureToggleSlug}


### PR DESCRIPTION
Updates the base and environment kustomize files to support the new `clientIdentifier` and `featureToggleSlug` environment variables.  Similar to the existing container port project level variable, this one will assume you have the project variables in place.